### PR TITLE
docs: add a package comment

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// githubactions provides an SDK for authoring GitHub Actions in Go. It has no
+// external dependencies and provides a Go-like interface for interacting with
+// GitHub Actions' build system.
 package githubactions
 
 import (


### PR DESCRIPTION
Adding a package comment is a "good thing" because it provides a nice
one-liner when the docs are viewed via pkg.go.dev (and other
documentation interfaces):

    https://pkg.go.dev/github.com/sethvargo/go-githubactions