### PR TITLE
Escape values for commands that define a message

### DIFF
--- a/actions_test.go
+++ b/actions_test.go
@@ -106,12 +106,20 @@ func TestAction_EndGroup(t *testing.T) {
 func TestAction_SetEnv(t *testing.T) {
 	t.Parallel()
 
-	var b bytes.Buffer
-	a := NewWithWriter(&b)
-	a.SetEnv("key", "value")
+	checks := []struct {
+		key, value, want string
+	}{
+		{"key", "value", "::set-env name=key::value\n"},
+		{"key", "this is 100% a special\n\r value!", "::set-env name=key::this is 100%25 a special%0A%0D value!\n"},
+	}
 
-	if got, want := b.String(), "::set-env name=key::value\n"; got != want {
-		t.Errorf("expected %q to be %q", got, want)
+	for _, check := range checks {
+		var b bytes.Buffer
+		a := NewWithWriter(&b)
+		a.SetEnv(check.key, check.value)
+		if got, want := b.String(), check.want; got != want {
+			t.Errorf("SetEnv(%q, %q): expected %q; got %q", check.key, check.value, got, want)
+		}
 	}
 }
 


### PR DESCRIPTION
A not-so-well-documented aspect of commands like set-env and set-output
is that their value must be escaped in a specific way.

In ec29893 this change was made for set-output, however the escaping is
required for all commands which define a message:

https://github.com/actions/toolkit/blob/9ad01e4fd30025e8858650d38e95cfe9193a3222/packages/core/src/command.ts#L74

Therefore we define escapeData to match the core JavaScript toolkit
equivalent, and call that as required for commands which define
messages.

We add a small table test for set-env in the process.

A TODO for a later change would be to mirror more closely the toolkit
implementation of Command with a struct type that encodes (via its
methods) this requirement on encoding messages and any other nuances we
might have missed.