### PR TITLE
Define a generic API to issue arbitrary action commands

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -220,25 +220,14 @@ func (c *Action) WithFieldsSlice(f []string) *Action {
 		m[pair[0]] = pair[1]
 	}
 
-	return &Action{
-		w:      c.w,
-		fields: m,
-	}
+	return c.WithFieldsMap(m)
 }
 
 // WithFieldsMap includes the provided fields in log output. The fields in "m"
 // are automatically converted to k=v pairs and sorted.
 func (c *Action) WithFieldsMap(m map[string]string) *Action {
-	// Not changing the function signature to 'map[string]interface{}' or
-	// 'CommandProperties' to keep the API backwards-compatible. Perform a
-	// manual type coversion instead.
-	fields := make(CommandProperties)
-	for k, v := range m {
-		fields[k] = v
-	}
-
 	return &Action{
 		w:      c.w,
-		fields: fields,
+		fields: m,
 	}
 }

--- a/actions.go
+++ b/actions.go
@@ -210,7 +210,7 @@ func (c *Action) Warningf(msg string, args ...interface{}) {
 // WithFieldsSlice includes the provided fields in log output. "f" must be a
 // slice of k=v pairs. The given slice will be sorted.
 func (c *Action) WithFieldsSlice(f []string) *Action {
-	m := make(CommandProperties, 0)
+	m := make(CommandProperties)
 	for _, s := range f {
 		pair := strings.SplitN(s, "=", 2)
 		if len(pair) < 2 {
@@ -232,7 +232,7 @@ func (c *Action) WithFieldsMap(m map[string]string) *Action {
 	// Not changing the function signature to 'map[string]interface{}' or
 	// 'CommandProperties' to keep the API backwards-compatible. Perform a
 	// manual type coversion instead.
-	fields := make(CommandProperties, 0)
+	fields := make(CommandProperties)
 	for k, v := range m {
 		fields[k] = v
 	}

--- a/actions.go
+++ b/actions.go
@@ -21,26 +21,25 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"sort"
 	"strings"
 )
 
 const (
-	addMaskFmt   = "::add-mask::%s\n"
-	addPathFmt   = "::add-path::%s\n"
-	setEnvFmt    = "::set-env name=%s::%s\n"
-	setOutputFmt = "::set-output name=%s::%s\n"
-	saveStateFmt = "::save-state name=%s::%s\n"
+	addMaskCmd   = "add-mask"
+	addPathCmd   = "add-path"
+	setEnvCmd    = "set-env"
+	setOutputCmd = "set-output"
+	saveStateCmd = "save-state"
 
-	addMatcherFmt    = "::add-matcher::%s\n"
-	removeMatcherFmt = "::remove-matcher owner=%s::\n"
+	addMatcherCmd    = "add-matcher"
+	removeMatcherCmd = "remove-matcher"
 
-	groupFmt    = "::group::%s\n"
-	endGroupFmt = "::endgroup::\n"
+	groupCmd    = "group"
+	endGroupCmd = "endgroup"
 
-	debugFmt   = "::debug%s::%s\n"
-	errorFmt   = "::error%s::%s\n"
-	warningFmt = "::warning%s::%s\n"
+	debugCmd   = "debug"
+	errorCmd   = "error"
+	warningCmd = "warning"
 )
 
 // New creates a new wrapper with helpers for outputting information in GitHub
@@ -60,33 +59,63 @@ func NewWithWriter(w io.Writer) *Action {
 // strings.
 type Action struct {
 	w      io.Writer
-	fields string
+	fields CommandProperties
+}
+
+// IssueCommand issues a new GitHub actions Command.
+func (c *Action) IssueCommand(cmd *Command) {
+	fmt.Fprintln(c.w, cmd.String())
 }
 
 // AddMask adds a new field mask for the given string "p". After called, future
 // attempts to log "p" will be replaced with "***" in log output.
 func (c *Action) AddMask(p string) {
-	fmt.Fprintf(c.w, addMaskFmt, escapeData(p))
+	// ::add-mask::<p>
+	c.IssueCommand(&Command{
+		Name:    addMaskCmd,
+		Message: p,
+	})
 }
 
 // AddMatcher adds a new matcher with the given file path.
 func (c *Action) AddMatcher(p string) {
-	fmt.Fprintf(c.w, addMatcherFmt, escapeData(p))
+	// ::add-matcher::<p>
+	c.IssueCommand(&Command{
+		Name:    addMatcherCmd,
+		Message: p,
+	})
 }
 
 // RemoveMatcher removes a matcher with the given owner name.
 func (c *Action) RemoveMatcher(o string) {
-	fmt.Fprintf(c.w, removeMatcherFmt, o)
+	// ::remove-matcher owner=<o>::
+	c.IssueCommand(&Command{
+		Name: removeMatcherCmd,
+		Properties: CommandProperties{
+			"owner": o,
+		},
+	})
 }
 
 // AddPath adds the string "p" to the path for the invocation.
 func (c *Action) AddPath(p string) {
-	fmt.Fprintf(c.w, addPathFmt, escapeData(p))
+	// ::add-path::<p>
+	c.IssueCommand(&Command{
+		Name:    addPathCmd,
+		Message: p,
+	})
 }
 
 // SaveState saves state to be used in the "finally" post job entry point.
 func (c *Action) SaveState(k, v string) {
-	fmt.Fprintf(c.w, saveStateFmt, k, escapeData(v))
+	// ::save-state name=<k>::<v>
+	c.IssueCommand(&Command{
+		Name:    saveStateCmd,
+		Message: v,
+		Properties: CommandProperties{
+			"name": k,
+		},
+	})
 }
 
 // GetInput gets the input by the given name.
@@ -99,51 +128,65 @@ func (c *Action) GetInput(i string) string {
 
 // Group starts a new collapsable region up to the next ungroup invocation.
 func (c *Action) Group(t string) {
-	fmt.Fprintf(c.w, groupFmt, escapeData(t))
+	// ::group::<t>
+	c.IssueCommand(&Command{
+		Name:    groupCmd,
+		Message: t,
+	})
 }
 
 // EndGroup ends the current group.
 func (c *Action) EndGroup() {
-	fmt.Fprint(c.w, endGroupFmt)
+	// ::endgroup::
+	c.IssueCommand(&Command{
+		Name: endGroupCmd,
+	})
 }
 
 // SetEnv sets an environment variable.
 func (c *Action) SetEnv(k, v string) {
-	fmt.Fprintf(c.w, setEnvFmt, k, escapeData(v))
+	// ::set-env name=<k>::<v>
+	c.IssueCommand(&Command{
+		Name:    setEnvCmd,
+		Message: v,
+		Properties: CommandProperties{
+			"name": k,
+		},
+	})
 }
 
 // SetOutput sets an output parameter.
 func (c *Action) SetOutput(k, v string) {
-	fmt.Fprintf(c.w, setOutputFmt, k, escapeData(v))
-}
-
-// escapeData escapes string values for presentation in the output of a
-// command. This is a not-so-well-documented requirement of commands that
-// define a message:
-//
-// https://github.com/actions/toolkit/blob/9ad01e4fd30025e8858650d38e95cfe9193a3222/packages/core/src/command.ts#L74
-//
-// The equivalent toolkit function can be found here:
-//
-// https://github.com/actions/toolkit/blob/9ad01e4fd30025e8858650d38e95cfe9193a3222/packages/core/src/command.ts#L92
-//
-func escapeData(v string) string {
-	v = strings.ReplaceAll(v, "%", "%25")
-	v = strings.ReplaceAll(v, "\r", "%0D")
-	v = strings.ReplaceAll(v, "\n", "%0A")
-	return v
+	// ::set-output name=<k>::<v>
+	c.IssueCommand(&Command{
+		Name:    setOutputCmd,
+		Message: v,
+		Properties: CommandProperties{
+			"name": k,
+		},
+	})
 }
 
 // Debugf prints a debug-level message. The arguments follow the standard Printf
 // arguments.
 func (c *Action) Debugf(msg string, args ...interface{}) {
-	fmt.Fprintf(c.w, debugFmt, c.fields, fmt.Sprintf(msg, args...))
+	// ::debug <c.fields>::<msg, args>
+	c.IssueCommand(&Command{
+		Name:       debugCmd,
+		Message:    fmt.Sprintf(msg, args...),
+		Properties: c.fields,
+	})
 }
 
 // Errorf prints a error-level message. The arguments follow the standard Printf
 // arguments.
 func (c *Action) Errorf(msg string, args ...interface{}) {
-	fmt.Fprintf(c.w, errorFmt, c.fields, fmt.Sprintf(msg, args...))
+	// ::error <c.fields>::<msg, args>
+	c.IssueCommand(&Command{
+		Name:       errorCmd,
+		Message:    fmt.Sprintf(msg, args...),
+		Properties: c.fields,
+	})
 }
 
 // Fatalf prints a error-level message and exits. This is equivalent to Errorf
@@ -156,25 +199,46 @@ func (c *Action) Fatalf(msg string, args ...interface{}) {
 // Warningf prints a warning-level message. The arguments follow the standard
 // Printf arguments.
 func (c *Action) Warningf(msg string, args ...interface{}) {
-	fmt.Fprintf(c.w, warningFmt, c.fields, fmt.Sprintf(msg, args...))
+	// ::warning <c.fields>::<msg, args>
+	c.IssueCommand(&Command{
+		Name:       warningCmd,
+		Message:    fmt.Sprintf(msg, args...),
+		Properties: c.fields,
+	})
 }
 
 // WithFieldsSlice includes the provided fields in log output. "f" must be a
 // slice of k=v pairs. The given slice will be sorted.
 func (c *Action) WithFieldsSlice(f []string) *Action {
-	sort.Strings(f)
+	m := make(CommandProperties, 0)
+	for _, s := range f {
+		pair := strings.SplitN(s, "=", 2)
+		if len(pair) < 2 {
+			panic(fmt.Sprintf("%q is not a proper k=v pair!", s))
+		}
+
+		m[pair[0]] = pair[1]
+	}
+
 	return &Action{
 		w:      c.w,
-		fields: " " + strings.Join(f, ","),
+		fields: m,
 	}
 }
 
 // WithFieldsMap includes the provided fields in log output. The fields in "m"
 // are automatically converted to k=v pairs and sorted.
 func (c *Action) WithFieldsMap(m map[string]string) *Action {
-	l := make([]string, 0, len(m))
+	// Not changing the function signature to 'map[string]interface{}' or
+	// 'CommandProperties' to keep the API backwards-compatible. Perform a
+	// manual type coversion instead.
+	fields := make(CommandProperties, 0)
 	for k, v := range m {
-		l = append(l, fmt.Sprintf("%s=%s", k, v))
+		fields[k] = v
 	}
-	return c.WithFieldsSlice(l)
+
+	return &Action{
+		w:      c.w,
+		fields: fields,
+	}
 }

--- a/actions_root.go
+++ b/actions_root.go
@@ -18,6 +18,11 @@ var (
 	defaultAction = New()
 )
 
+// IssueCommand issues an arbitrary GitHub actions Command.
+func IssueCommand(cmd *Command) {
+	defaultAction.IssueCommand(cmd)
+}
+
 // AddMask adds a new field mask for the given string "p". After called, future
 // attempts to log "p" will be replaced with "***" in log output.
 func AddMask(p string) {

--- a/actions_test.go
+++ b/actions_test.go
@@ -19,6 +19,21 @@ import (
 	"testing"
 )
 
+func TestAction_IssueCommand(t *testing.T) {
+	t.Parallel()
+
+	var b bytes.Buffer
+	a := NewWithWriter(&b)
+	a.IssueCommand(&Command{
+		Name:    "foo",
+		Message: "bar",
+	})
+
+	if got, want := b.String(), "::foo::bar\n"; got != want {
+		t.Errorf("expected %q to be %q", got, want)
+	}
+}
+
 func TestAction_AddMask(t *testing.T) {
 	t.Parallel()
 

--- a/command.go
+++ b/command.go
@@ -1,0 +1,121 @@
+package githubactions
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// CommandProperties is a named "map[string]interface{}" type to hold key-value
+// pairs passed to an actions command.
+type CommandProperties map[string]interface{}
+
+// String encodes the CommandProperties to a string as comma separated
+// 'key=value' pairs. The pairs are joined in a chronological order.
+func (props *CommandProperties) String() string {
+	l := make([]string, 0, len(*props))
+	for k, v := range *props {
+		l = append(l, fmt.Sprintf("%s=%s", k, escapeProperty(v)))
+	}
+
+	sort.Strings(l)
+	return strings.Join(l, ",")
+}
+
+// Command can be issued by a GitHub action by writing to `stdout` with
+// following format.
+//
+// ::name key=value,key=value::message
+//
+//  Examples:
+//    ::warning::This is the message
+//    ::set-env name=MY_VAR::some value
+type Command struct {
+	Name       string
+	Message    interface{}
+	Properties CommandProperties
+}
+
+// String encodes the Command to a string in the following format:
+//
+// ::name key=value,key=value::message
+func (cmd *Command) String() string {
+	// https://github.com/actions/toolkit/blob/9ad01e4fd30025e8858650d38e95cfe9193a3222/packages/core/src/command.ts#L43-L45
+	if cmd.Name == "" {
+		cmd.Name = "missing.command"
+	}
+
+	const cmdSeparator = "::"
+	var builder strings.Builder
+	builder.WriteString(cmdSeparator)
+	builder.WriteString(cmd.Name)
+	if len(cmd.Properties) > 0 {
+		builder.WriteString(" ")
+		builder.WriteString(cmd.Properties.String())
+	}
+
+	builder.WriteString(cmdSeparator)
+	builder.WriteString(escapeData(cmd.Message))
+	return builder.String()
+}
+
+// toCommandValue sanitizes an input into a string so it can be passed with a
+// Command safely.
+//
+// The equivalent toolkit function can be found here:
+//
+// https://github.com/actions/toolkit/blob/9ad01e4fd30025e8858650d38e95cfe9193a3222/packages/core/src/command.ts#L83-L90
+func toCommandValue(i interface{}) string {
+	switch v := i.(type) {
+	case nil:
+		return ""
+	case string:
+		return v
+	case fmt.Stringer:
+		return v.String()
+	default:
+		data, err := json.Marshal(v)
+		if err != nil {
+			panic(err)
+		}
+
+		return string(data)
+	}
+}
+
+// escapeData escapes string values for presentation in the output of a command.
+// This is a not-so-well-documented requirement of commands that define a
+// message:
+//
+// https://github.com/actions/toolkit/blob/9ad01e4fd30025e8858650d38e95cfe9193a3222/packages/core/src/command.ts#L74
+//
+// The equivalent toolkit function can be found here:
+//
+// https://github.com/actions/toolkit/blob/9ad01e4fd30025e8858650d38e95cfe9193a3222/packages/core/src/command.ts#L92
+//
+func escapeData(i interface{}) string {
+	v := toCommandValue(i)
+	v = strings.ReplaceAll(v, "%", "%25")
+	v = strings.ReplaceAll(v, "\r", "%0D")
+	v = strings.ReplaceAll(v, "\n", "%0A")
+	return v
+}
+
+// escapeData escapes command property values for presentation in the output of
+// a command.
+//
+// https://github.com/actions/toolkit/blob/9ad01e4fd30025e8858650d38e95cfe9193a3222/packages/core/src/command.ts#L68
+//
+// The equivalent toolkit function can be found here:
+//
+// https://github.com/actions/toolkit/blob/1cc56db0ff126f4d65aeb83798852e02a2c180c3/packages/core/src/command.ts#L99-L106
+func escapeProperty(i interface{}) string {
+	v := toCommandValue(i)
+	v = strings.ReplaceAll(v, "%", "%25")
+	v = strings.ReplaceAll(v, "\r", "%0D")
+	v = strings.ReplaceAll(v, "\n", "%0A")
+	v = strings.ReplaceAll(v, ":", "%3A")
+	v = strings.ReplaceAll(v, ",", "%2C")
+	return v
+}

--- a/command_test.go
+++ b/command_test.go
@@ -1,0 +1,36 @@
+package githubactions
+
+import "testing"
+
+func TestCommandProperties_String(t *testing.T) {
+	t.Parallel()
+
+	props := CommandProperties{"hello": "world"}
+	if got, want := props.String(), "hello=world"; got != want {
+		t.Errorf("expected %q to be %q", got, want)
+	}
+
+	props["foo"] = "bar"
+	if got, want := props.String(), "foo=bar,hello=world"; got != want {
+		t.Errorf("expected %q to be %q", got, want)
+	}
+}
+
+func TestCommand_String(t *testing.T) {
+	t.Parallel()
+
+	cmd := Command{Name: "foo"}
+	if got, want := cmd.String(), "::foo::"; got != want {
+		t.Errorf("expected %q to be %q", got, want)
+	}
+
+	cmd.Message = "bar"
+	if got, want := cmd.String(), "::foo::bar"; got != want {
+		t.Errorf("expected %q to be %q", got, want)
+	}
+
+	cmd.Properties = CommandProperties{"bar": "foo"}
+	if got, want := cmd.String(), "::foo bar=foo::bar"; got != want {
+		t.Errorf("expected %q to be %q", got, want)
+	}
+}


### PR DESCRIPTION
The goal here is to closely shadow the TypeScript counterpart.

https://github.com/actions/toolkit/blob/main/packages/core/src/command.ts

Essentially, a command is divided in 3 parts: name, message and properties. All three parts are optional in the TypeScript API.
Properties are comma-separated `key=val` pairs accepted by some commands. e.g.

```
::name properties::message
```

Moreover, the data type of `message` and `val` (in properties) is not limited to `string`. The TypeScript counterpart accepts generic types for these arguments. A common function `toCommandValue` is defined in the TS API which JSON encodes non-string values for `message` and `val`. Another function `escapeProperty` is used to sanitize `val` part of the properties.

This PR proposes all these changes and migrates the existing APIs to use them.

Related to #8 #6 #5 #4