### PR TITLE
Remove deprecated `NewWithWriter()`.

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -64,15 +64,6 @@ func New(opts ...Option) *Action {
 	return a
 }
 
-// NewWithWriter creates a wrapper using the given writer. This is useful for
-// tests. The given writer cannot add any prefixes to the string, since GitHub
-// requires these special strings to match a very particular format.
-//
-// Deprecated: Use New() with WithWriter instead.
-func NewWithWriter(w io.Writer) *Action {
-	return New(WithWriter(w))
-}
-
 // Action is an internal wrapper around GitHub Actions' output and magic
 // strings.
 type Action struct {

--- a/actions_test.go
+++ b/actions_test.go
@@ -21,22 +21,6 @@ import (
 	"testing"
 )
 
-func TestNewWithWriter(t *testing.T) {
-	t.Parallel()
-
-	var b bytes.Buffer
-	a := NewWithWriter(&b)
-
-	a.IssueCommand(&Command{
-		Name:    "foo",
-		Message: "bar",
-	})
-
-	if got, want := b.String(), "::foo::bar\n"; got != want {
-		t.Errorf("expected %q to be %q", got, want)
-	}
-}
-
 func TestAction_IssueCommand(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
In the process, also getting `actions.go` and `command.go` to 100% test coverage.