### PR TITLE
Adding tests to get `actions.go` and `command.go` to 100% test coverage.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+coverage.out

--- a/actions.go
+++ b/actions.go
@@ -25,6 +25,11 @@ import (
 	"strings"
 )
 
+var (
+	// osExit allows `os.Exit()` to be stubbed during testing.
+	osExit = os.Exit
+)
+
 const (
 	addMaskCmd   = "add-mask"
 	setOutputCmd = "set-output"
@@ -263,7 +268,7 @@ func (c *Action) Errorf(msg string, args ...interface{}) {
 // followed by os.Exit(1).
 func (c *Action) Fatalf(msg string, args ...interface{}) {
 	c.Errorf(msg, args...)
-	os.Exit(1)
+	osExit(1)
 }
 
 // Infof prints a info-level message. The arguments follow the standard Printf

--- a/actions_test.go
+++ b/actions_test.go
@@ -21,6 +21,32 @@ import (
 	"testing"
 )
 
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	var b bytes.Buffer
+	a := New(
+		WithWriter(&b),
+		nil,
+		WithGetenv(func(key string) string {
+			return key
+		}),
+	)
+
+	a.IssueCommand(&Command{
+		Name:    "foo",
+		Message: "bar",
+	})
+
+	if got, want := b.String(), "::foo::bar\n"; got != want {
+		t.Errorf("expected %q to be %q", got, want)
+	}
+
+	if got, want := a.GetInput("quux"), "INPUT_QUUX"; got != want {
+		t.Errorf("expected %q to be %q", got, want)
+	}
+}
+
 func TestNewWithWriter(t *testing.T) {
 	t.Parallel()
 

--- a/actions_test.go
+++ b/actions_test.go
@@ -340,8 +340,6 @@ func TestAction_Errorf(t *testing.T) {
 }
 
 func TestAction_Fatalf(t *testing.T) {
-	t.Parallel()
-
 	calls := []int{}
 	finalizer := osExitMock(&calls)
 	defer finalizer()

--- a/actions_test.go
+++ b/actions_test.go
@@ -375,6 +375,22 @@ func TestAction_WithFieldsSlice(t *testing.T) {
 	}
 }
 
+func TestAction_WithFieldsSlice_Panic(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		want := `"no-equals" is not a proper k=v pair!`
+		if got := recover(); got != want {
+			t.Errorf("expected %q to be %q", got, want)
+		}
+	}()
+
+	var b bytes.Buffer
+	a := New(WithWriter(&b))
+	a = a.WithFieldsSlice([]string{"no-equals"})
+	a.Debugf("fail: %s", "thing")
+}
+
 func TestAction_WithFieldsMap(t *testing.T) {
 	t.Parallel()
 

--- a/actions_test.go
+++ b/actions_test.go
@@ -340,6 +340,8 @@ func TestAction_Errorf(t *testing.T) {
 }
 
 func TestAction_Fatalf(t *testing.T) {
+	// NOTE: This test case cannot be `t.Parallel()` because it patches a
+	//       global `osExit`, so could impact other (concurrent) test runs.
 	calls := []int{}
 	finalizer := osExitMock(&calls)
 	defer finalizer()

--- a/command_test.go
+++ b/command_test.go
@@ -37,4 +37,9 @@ func TestCommand_String(t *testing.T) {
 	if got, want := cmd.String(), "::foo bar=foo::bar"; got != want {
 		t.Errorf("expected %q to be %q", got, want)
 	}
+
+	cmd = Command{Message: "quux"}
+	if got, want := cmd.String(), "::missing.command::quux"; got != want {
+		t.Errorf("expected %q to be %q", got, want)
+	}
 }

--- a/command_test.go
+++ b/command_test.go
@@ -24,12 +24,16 @@ func TestCommand_String(t *testing.T) {
 		t.Errorf("expected %q to be %q", got, want)
 	}
 
-	cmd.Message = "bar"
+	cmd = Command{Name: "foo", Message: "bar"}
 	if got, want := cmd.String(), "::foo::bar"; got != want {
 		t.Errorf("expected %q to be %q", got, want)
 	}
 
-	cmd.Properties = CommandProperties{"bar": "foo"}
+	cmd = Command{
+		Name:       "foo",
+		Message:    "bar",
+		Properties: CommandProperties{"bar": "foo"},
+	}
 	if got, want := cmd.String(), "::foo bar=foo::bar"; got != want {
 		t.Errorf("expected %q to be %q", got, want)
 	}


### PR DESCRIPTION
Also factoring out `os.Exit()` as a mutable `var osExit`.