### PR TITLE
Add Noticef, fix Infof.

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -56,8 +56,9 @@ const (
 	endGroupCmd = "endgroup"
 
 	debugCmd   = "debug"
-	errorCmd   = "error"
+	noticeCmd  = "notice"
 	warningCmd = "warning"
+	errorCmd   = "error"
 
 	errFileCmdFmt = "unable to write command to the environment file: %s"
 )
@@ -268,6 +269,28 @@ func (c *Action) Debugf(msg string, args ...interface{}) {
 	})
 }
 
+// Noticef prints a notice-level message. The arguments follow the standard Printf
+// arguments.
+func (c *Action) Noticef(msg string, args ...interface{}) {
+	// ::notice <c.fields>::<msg, args>
+	c.IssueCommand(&Command{
+		Name:       noticeCmd,
+		Message:    fmt.Sprintf(msg, args...),
+		Properties: c.fields,
+	})
+}
+
+// Warningf prints a warning-level message. The arguments follow the standard Printf
+// arguments.
+func (c *Action) Warningf(msg string, args ...interface{}) {
+	// ::warning <c.fields>::<msg, args>
+	c.IssueCommand(&Command{
+		Name:       warningCmd,
+		Message:    fmt.Sprintf(msg, args...),
+		Properties: c.fields,
+	})
+}
+
 // Errorf prints a error-level message. The arguments follow the standard Printf
 // arguments.
 func (c *Action) Errorf(msg string, args ...interface{}) {
@@ -291,17 +314,6 @@ func (c *Action) Fatalf(msg string, args ...interface{}) {
 func (c *Action) Infof(msg string, args ...interface{}) {
 	// ::info <c.fields>::<msg, args>
 	fmt.Fprintf(c.w, msg, args...)
-}
-
-// Warningf prints a warning-level message. The arguments follow the standard
-// Printf arguments.
-func (c *Action) Warningf(msg string, args ...interface{}) {
-	// ::warning <c.fields>::<msg, args>
-	c.IssueCommand(&Command{
-		Name:       warningCmd,
-		Message:    fmt.Sprintf(msg, args...),
-		Properties: c.fields,
-	})
 }
 
 // WithFieldsSlice includes the provided fields in log output. "f" must be a

--- a/actions.go
+++ b/actions.go
@@ -309,11 +309,17 @@ func (c *Action) Fatalf(msg string, args ...interface{}) {
 	osExit(1)
 }
 
-// Infof prints a info-level message. The arguments follow the standard Printf
-// arguments.
+// Infof prints message to stdout without any level annotations.
+// The arguments follow the standard Printf arguments.
 func (c *Action) Infof(msg string, args ...interface{}) {
-	// ::info <c.fields>::<msg, args>
-	fmt.Fprintf(c.w, msg, args...)
+	s := fmt.Sprintf(msg, args...)
+
+	// behave like other commands and log.Printf by adding newline if needed
+	if len(s) == 0 || s[len(s)-1] != '\n' {
+		s += "\n"
+	}
+
+	fmt.Fprint(c.w, s)
 }
 
 // WithFieldsSlice includes the provided fields in log output. "f" must be a

--- a/actions_test.go
+++ b/actions_test.go
@@ -400,6 +400,18 @@ func TestAction_Infof(t *testing.T) {
 	}
 }
 
+func TestAction_Infof_NoNewline(t *testing.T) {
+	t.Parallel()
+
+	var b bytes.Buffer
+	a := New(WithWriter(&b))
+	a.Infof("info: %s", "thing")
+
+	if got, want := b.String(), "info: thing\n"; got != want {
+		t.Errorf("expected %q to be %q", got, want)
+	}
+}
+
 func TestAction_WithFieldsSlice(t *testing.T) {
 	t.Parallel()
 

--- a/actions_test.go
+++ b/actions_test.go
@@ -332,6 +332,30 @@ func TestAction_Debugf(t *testing.T) {
 	}
 }
 
+func TestAction_Noticef(t *testing.T) {
+	t.Parallel()
+
+	var b bytes.Buffer
+	a := New(WithWriter(&b))
+	a.Noticef("fail: %s", "thing")
+
+	if got, want := b.String(), "::notice::fail: thing\n"; got != want {
+		t.Errorf("expected %q to be %q", got, want)
+	}
+}
+
+func TestAction_Warningf(t *testing.T) {
+	t.Parallel()
+
+	var b bytes.Buffer
+	a := New(WithWriter(&b))
+	a.Warningf("fail: %s", "thing")
+
+	if got, want := b.String(), "::warning::fail: thing\n"; got != want {
+		t.Errorf("expected %q to be %q", got, want)
+	}
+}
+
 func TestAction_Errorf(t *testing.T) {
 	t.Parallel()
 
@@ -360,18 +384,6 @@ func TestAction_Fatalf(t *testing.T) {
 	}
 
 	if got, want := calls, []int{1}; !reflect.DeepEqual(got, want) {
-		t.Errorf("expected %q to be %q", got, want)
-	}
-}
-
-func TestAction_Warningf(t *testing.T) {
-	t.Parallel()
-
-	var b bytes.Buffer
-	a := New(WithWriter(&b))
-	a.Warningf("fail: %s", "thing")
-
-	if got, want := b.String(), "::warning::fail: thing\n"; got != want {
 		t.Errorf("expected %q to be %q", got, want)
 	}
 }


### PR DESCRIPTION
The first commit adds support for [notice messages](https://docs.github.com/en/actions/learn-github-actions/workflow-commands-for-github-actions#setting-a-notice-message).

The second fixes Infof by adding a trailing \n if needed. Without it, the next command will be ignored, as it will be a part of the same line. For example:
```
My Infof log message.::set-output name=output::value
```
