### PR TITLE
Fix SetEnv overwriting the result of the previous call

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -125,10 +125,14 @@ func (c *Action) IssueFileCommand(cmd *Command) error {
 
 	filepath := c.getenv(e)
 	msg := []byte(cmd.Message + EOF)
-	if err := ioutil.WriteFile(filepath, msg, os.ModeAppend); err != nil {
+	f, err := os.OpenFile(filepath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
 		return fmt.Errorf(errFileCmdFmt, err)
 	}
-
+	defer f.Close()
+	if _, err := f.Write(msg); err != nil {
+		return fmt.Errorf(errFileCmdFmt, err)
+	}
 	return nil
 }
 

--- a/actions_test.go
+++ b/actions_test.go
@@ -290,6 +290,7 @@ func TestAction_SetEnv(t *testing.T) {
 	fakeGetenvFunc := newFakeGetenvFunc(t, envGitHubEnv, file.Name())
 	a := New(WithWriter(&b), WithGetenv(fakeGetenvFunc))
 	a.SetEnv("key", "value")
+	a.SetEnv("key2", "value2")
 
 	// expect an empty stdout buffer
 	if got, want := b.String(), ""; got != want {
@@ -303,6 +304,7 @@ func TestAction_SetEnv(t *testing.T) {
 	}
 
 	want := "key<<_GitHubActionsFileCommandDelimeter_" + EOF + "value" + EOF + "_GitHubActionsFileCommandDelimeter_" + EOF
+	want += "key2<<_GitHubActionsFileCommandDelimeter_" + EOF + "value2" + EOF + "_GitHubActionsFileCommandDelimeter_" + EOF
 	if got := string(data); got != want {
 		t.Errorf("expected %q to be %q", got, want)
 	}


### PR DESCRIPTION
The way WriteFile was being called does not actually append to the file. This PR fixes opening the file in append mode and updates the test.