### PR TITLE
Expose Action.Getenv

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -405,6 +405,12 @@ func (c *Action) GetIDToken(ctx context.Context, audience string) (string, error
 	return tokenResp.Value, nil
 }
 
+// Getenv retrieves the value of the environment variable named by the key.
+// It uses an internal function that can be set with `WithGetenv`.
+func (c *Action) Getenv(key string) string {
+	return c.getenv(key)
+}
+
 // GetenvFunc is an abstraction to make tests feasible for commands that
 // interact with environment variables.
-type GetenvFunc func(k string) string
+type GetenvFunc func(key string) string

--- a/options.go
+++ b/options.go
@@ -19,7 +19,7 @@ import (
 	"net/http"
 )
 
-// Option is a modifier for an Action
+// Option is a modifier for an Action.
 type Option func(*Action) *Action
 
 // WithWriter sets the writer function on an Action. By default, this will

--- a/options_test.go
+++ b/options_test.go
@@ -65,7 +65,7 @@ func TestWithGetenv(t *testing.T) {
 	})
 
 	opt(a)
-	if got, want := a.getenv("any"), "sentinel"; got != want {
+	if got, want := a.Getenv("any"), "sentinel"; got != want {
 		t.Errorf("expected %q to be %q", got, want)
 	}
 }


### PR DESCRIPTION
This commit makes `Action.getenv` accessible without making it settable without using `WithGetenv`. That allows tests with a fake environment to pass only Action.

For example, there I have to pass both Action and a fake getenv function to the function I want to test: https://github.com/FerretDB/github-actions/blob/e34bef95940ca0d735069846e840f4e0aacddfc9/extract-docker-tag/main_test.go#L11-L39