### PR TITLE
Panic on errors and remove deprecated functions

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -48,19 +48,10 @@ jobs:
     runs-on: '${{ matrix.os }}'
 
     steps:
-    - uses: 'actions/checkout@v2'
+    - uses: 'actions/checkout@v3'
 
-    - uses: 'actions/setup-go@v2'
+    - uses: 'actions/setup-go@v3'
       with:
         go-version: '${{ matrix.go }}'
 
-    - uses: 'actions/cache@v2'
-      with:
-        path: '~/go/pkg/mod'
-        key: '${{ matrix.os }}-go-${{ matrix.go }}-${{ hashFiles(''**/go.sum'') }}'
-        restore-keys: |
-          ${{ matrix.os }}-go-${{ matrix.go }}
-          ${{ matrix.os }}-go-
-
-    - name: 'Test'
-      run: 'make test-acc'
+    - run: 'make test-acc'

--- a/actions_root.go
+++ b/actions_root.go
@@ -26,8 +26,8 @@ func IssueCommand(cmd *Command) {
 }
 
 // IssueFileCommand issues a new GitHub actions Command using environment files.
-func IssueFileCommand(cmd *Command) error {
-	return defaultAction.IssueFileCommand(cmd)
+func IssueFileCommand(cmd *Command) {
+	defaultAction.IssueFileCommand(cmd)
 }
 
 // AddMask adds a new field mask for the given string "p". After called, future


### PR DESCRIPTION
Previously, if writing to a env/path file failed, the library would silently fail if writing to the file failed. Similarly, if writing to an output stream fails, the library would silently fail. This updates the behavior to panic on these low-level errors.

Additionally, this removes deprecated ways of setting environment variables and paths given the new GitHub runners have been available for months. It also removes deprecated library functions.