### PR TITLE
Support for repository name and owner on the github context

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -471,9 +471,13 @@ type GitHubContext struct {
 	GraphqlURL string `env:"GITHUB_GRAPHQL_URL,default=https://api.github.com/graphql"`
 
 	// Repository is the owner and repository name. For example, octocat/Hello-World
+	// It is not recommended to use this field to acquire the repository name
+	// but to use the Repo method instead.
 	Repository string `env:"GITHUB_REPOSITORY"`
 
 	// RepositoryOwner is the repository owner. For example, octocat
+	// It is not recommended to use this field to acquire the repository owner
+	// but to use the Repo method instead.
 	RepositoryOwner string `env:"GITHUB_REPOSITORY_OWNER"`
 
 	// Event is populated by parsing the file at EventPath, if it exists.


### PR DESCRIPTION
Adds support for getting the repository name and repository owner for the repository that triggered the Github Actions workflow.

- The `GITHUB_REPOSITORY` environment variable is read into the `Repository` field on the `GitHubContext`.
- The `GITHUB_REPOSITORY_OWNER` environment variable is read into the `RepositoryOwner` field on the `GitHubContext`.
- A `Repo` method on the `GitHubContext` is added to retrieve the owner and repository name separately from the various places it can be retrieved (env vars and event payload).