### PR TITLE
README: Fix build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # GitHub Actions SDK (Go)
 
 [![GoDoc](https://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)](https://pkg.go.dev/github.com/sethvargo/go-githubactions)
-[![GitHub Actions](https://img.shields.io/github/workflow/status/sethvargo/go-githubactions/Test?style=flat-square)](https://github.com/sethvargo/go-githubactions/actions?query=workflow%3ATest)
+[![GitHub Actions](https://img.shields.io/github/actions/workflow/status/sethvargo/go-githubactions/unit.yml?branch=main&style=flat-square)](https://github.com/sethvargo/go-githubactions/actions?query=workflow%3ATest)
 
 This library provides an SDK for authoring [GitHub Actions][gh-actions] in Go. It has no external dependencies and provides a Go-like interface for interacting with GitHub Actions' build system.
 


### PR DESCRIPTION
The badge currently renders a link to https://github.com/badges/shields/issues/8671 which specifies a change to the badge URL.

This PR makes the change suggested on the issue, which results in the badge being rendered correctly.