### PR TITLE
chore: fixed minimal Dockerfile example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ By default, GitHub Actions expects actions to be written in Node.js. For other l
 ```dockerfile
 # your-repo/Dockerfile
 FROM golang:1.18
+WORKDIR /src
+COPY . . 
 RUN go build -o /bin/app .
 ENTRYPOINT ["/bin/app"]
 ```


### PR DESCRIPTION
Hi,

The minimal Dockerfile given in the readme doesn't actually work. This PR fixes that. I verified that the Dockerfile works beforehand.