### PR TITLE
feat: follow the breaking changes in `go-envconfig`

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -540,10 +540,12 @@ func (c *GitHubContext) Repo() (string, string) {
 // that triggered the workflow
 func (c *Action) Context() (*GitHubContext, error) {
 	ctx := context.Background()
-	lookuper := &wrappedLookuper{f: c.getenv}
 
 	var githubContext GitHubContext
-	if err := envconfig.ProcessWith(ctx, &githubContext, lookuper); err != nil {
+	if err := envconfig.ProcessWith(ctx, &envconfig.Config{
+		Target:   &githubContext,
+		Lookuper: &wrappedLookuper{f: c.getenv},
+	}); err != nil {
 		return nil, fmt.Errorf("could not process github context variables: %w", err)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -14,9 +14,11 @@
 
 module github.com/sethvargo/go-githubactions
 
-go 1.18
+go 1.21
+
+toolchain go1.21.6
 
 require (
-	github.com/google/go-cmp v0.5.8
-	github.com/sethvargo/go-envconfig v0.8.0
+	github.com/google/go-cmp v0.6.0
+	github.com/sethvargo/go-envconfig v1.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
-github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/sethvargo/go-envconfig v0.8.0 h1:AcmdAewSFAc7pQ1Ghz+vhZkilUtxX559QlDuLLiSkdI=
-github.com/sethvargo/go-envconfig v0.8.0/go.mod h1:Iz1Gy1Sf3T64TQlJSvee81qDhf7YIlt8GMUX6yyNFs0=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/sethvargo/go-envconfig v1.0.0 h1:1C66wzy4QrROf5ew4KdVw942CQDa55qmlYmw9FZxZdU=
+github.com/sethvargo/go-envconfig v1.0.0/go.mod h1:Lzc75ghUn5ucmcRGIdGQ33DKJrcjk4kihFYgSTBmjIc=


### PR DESCRIPTION
Hello,

I notice that `go-githubactions` haven't followed the recent `go-envconfig` breaking changes yet when I upgraded all of the dependencies in my project.

It looks like a simple fix so just submits a fix for your review.

When I ran `go get` locally, `go.mod` file has some changes other than `go-envconfig` version. Please just let me know if you don't like the change.