### PR TITLE
Modernize for Go 1.25

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -42,9 +42,9 @@ jobs:
     runs-on: '${{ matrix.os }}'
 
     steps:
-    - uses: 'actions/checkout@v4'
+    - uses: 'actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0' # ratchet:actions/checkout@v7
 
-    - uses: 'actions/setup-go@v5'
+    - uses: 'actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e' # ratchet:actions/setup-go@v7
       with:
         go-version-file: 'go.mod'
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ By default, GitHub Actions expects actions to be written in Node.js. For other l
 
 ```dockerfile
 # your-repo/Dockerfile
-FROM golang:1.18
+FROM golang:1.25
 WORKDIR /src
 COPY . .
 RUN go build -o /bin/app .
@@ -108,10 +108,9 @@ steps:
 Now we can precompile and publish our Go Action as a Docker container, but we need to make it much, much smaller first. This can be achieved using multi-stage Docker builds:
 
 ```dockerfile
-FROM golang:1.18 AS builder
+FROM golang:1.25 AS builder
 
-ENV GO111MODULE=on \
-  CGO_ENABLED=0 \
+ENV CGO_ENABLED=0 \
   GOOS=linux \
   GOARCH=amd64
 
@@ -149,4 +148,4 @@ much faster builds.
 
 
 [gh-actions]: https://github.com/features/actions
-[godoc]: https://godoc.org/github.com/sethvargo/go-githubactions
+[godoc]: https://pkg.go.dev/github.com/sethvargo/go-githubactions

--- a/actions.go
+++ b/actions.go
@@ -382,12 +382,12 @@ func (c *Action) Infof(msg string, args ...any) {
 func (c *Action) WithFieldsSlice(f []string) *Action {
 	m := make(CommandProperties)
 	for _, s := range f {
-		pair := strings.SplitN(s, "=", 2)
-		if len(pair) < 2 {
+		key, value, ok := strings.Cut(s, "=")
+		if !ok {
 			panic(fmt.Sprintf("%q is not a proper k=v pair!", s))
 		}
 
-		m[pair[0]] = pair[1]
+		m[key] = value
 	}
 
 	return c.WithFieldsMap(m)
@@ -431,7 +431,7 @@ func (c *Action) GetIDToken(ctx context.Context, audience string) (string, error
 		u.RawQuery = q.Encode()
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {
 		return "", fmt.Errorf("failed to create HTTP request: %w", err)
 	}
@@ -443,15 +443,13 @@ func (c *Action) GetIDToken(ctx context.Context, audience string) (string, error
 	}
 	defer resp.Body.Close()
 
-	// This has moved to the io package in Go 1.16, but we still support up to Go
-	// 1.13 for now.
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 64*1000))
 	if err != nil {
 		return "", fmt.Errorf("failed to read response body: %w", err)
 	}
 	body = bytes.TrimSpace(body)
 
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		return "", &RequestFailedError{StatusCode: resp.StatusCode, Body: string(body)}
 	}
 
@@ -529,11 +527,8 @@ func (c *GitHubContext) Repo() (string, string) {
 
 	// Based on https://github.com/actions/toolkit/blob/main/packages/github/src/context.ts
 	if c.Repository != "" {
-		parts := strings.SplitN(c.Repository, "/", 2)
-		if len(parts) == 1 {
-			return parts[0], ""
-		}
-		return parts[0], parts[1]
+		owner, name, _ := strings.Cut(c.Repository, "/")
+		return owner, name
 	}
 
 	// If c.Repository is empty attempt to get the repo from the Event data.

--- a/actions_test.go
+++ b/actions_test.go
@@ -600,8 +600,6 @@ func TestAction_GetIDToken(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -757,8 +755,6 @@ func TestAction_Context(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -836,8 +832,6 @@ func TestGitHubContext_Repo(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/command.go
+++ b/command.go
@@ -16,7 +16,7 @@ package githubactions
 
 import (
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 )
 
@@ -37,7 +37,7 @@ func (props *CommandProperties) String() string {
 		l = append(l, fmt.Sprintf("%s=%s", k, escapeProperty(v)))
 	}
 
-	sort.Strings(l)
+	slices.Sort(l)
 	return strings.Join(l, ",")
 }
 
@@ -46,9 +46,9 @@ func (props *CommandProperties) String() string {
 //
 // ::name key=value,key=value::message
 //
-//  Examples:
-//    ::warning::This is the message
-//    ::set-env name=MY_VAR::some value
+//	Examples:
+//	  ::warning::This is the message
+//	  ::set-env name=MY_VAR::some value
 type Command struct {
 	Name       string
 	Message    string
@@ -60,13 +60,14 @@ type Command struct {
 // ::name key=value,key=value::message
 func (cmd *Command) String() string {
 	// https://github.com/actions/toolkit/blob/9ad01e4fd30025e8858650d38e95cfe9193a3222/packages/core/src/command.ts#L43-L45
-	if cmd.Name == "" {
-		cmd.Name = "missing.command"
+	name := cmd.Name
+	if name == "" {
+		name = "missing.command"
 	}
 
 	var builder strings.Builder
 	builder.WriteString(cmdSeparator)
-	builder.WriteString(cmd.Name)
+	builder.WriteString(name)
 	if len(cmd.Properties) > 0 {
 		builder.WriteString(cmdPropertiesPrefix)
 		builder.WriteString(cmd.Properties.String())
@@ -86,7 +87,6 @@ func (cmd *Command) String() string {
 // The equivalent toolkit function can be found here:
 //
 // https://github.com/actions/toolkit/blob/9ad01e4fd30025e8858650d38e95cfe9193a3222/packages/core/src/command.ts#L92
-//
 func escapeData(v string) string {
 	v = strings.ReplaceAll(v, "%", "%25")
 	v = strings.ReplaceAll(v, "\r", "%0D")

--- a/eof_crlf.go
+++ b/eof_crlf.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build windows
-// +build windows
 
 package githubactions
 

--- a/eof_lf.go
+++ b/eof_lf.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build !windows
-// +build !windows
 
 package githubactions
 

--- a/go.mod
+++ b/go.mod
@@ -14,4 +14,4 @@
 
 module github.com/sethvargo/go-githubactions
 
-go 1.21
+go 1.25


### PR DESCRIPTION
Bumps the module to Go 1.25 and applies the simplifications the newer language and toolchain allow, plus a couple of bug and doc fixes.

## Go 1.25 and simplifications

- `go.mod`: `go 1.21` -> `go 1.25`.
- Drop the obsolete `// +build` constraint lines from the EOF files (the modernizer flags them; only `//go:build` is needed since Go 1.18).
- `sort.Strings` -> `slices.Sort` in `CommandProperties.String`.
- `strings.SplitN(s, sep, 2)` -> `strings.Cut` in `WithFieldsSlice` and `GitHubContext.Repo`.
- Remove the now-unneeded per-iteration `tc := tc` copies in the table tests; loop variables are per-iteration since Go 1.22.
- Delete the stale "we still support up to Go 1.13" comment on the `io.ReadAll` call.

## Bug fix

`Command.String()` mutated its receiver by assigning `cmd.Name = "missing.command"` when `Name` was empty, so calling `String()` had a visible side effect on the caller's struct. It now computes the fallback in a local.

## Minor cleanups

- Use `http.MethodGet` and `http.StatusOK` instead of the `"GET"` and `200` literals.
- Refresh the README: `godoc.org` -> `pkg.go.dev`, the Dockerfile examples `golang:1.18` -> `golang:1.25`, and drop the obsolete `GO111MODULE=on`.

## CI

Pin `actions/checkout` and `actions/setup-go` to commit SHAs with ratchet, keeping the `# ratchet:` version comments.

## Verification

`make test-acc` (race), `go vet ./...`, `gofmt`, the gopls modernizer, and `ratchet lint` all pass clean.
